### PR TITLE
fix serialization of Fluent::EventTime objects

### DIFF
--- a/lib/fluent/plugin/out_bufferize.rb
+++ b/lib/fluent/plugin/out_bufferize.rb
@@ -37,7 +37,7 @@ module Fluent
 
       def each(&block)
         @chunk.open do |io|
-          u = MessagePack::Unpacker.new(io)
+          u = Fluent::MessagePackFactory.unpacker(io)
           begin
             if @count > 0
               $log.debug "Bufferize: skip first #{@count} messages" 
@@ -109,7 +109,8 @@ module Fluent
     end
 
     def format(tag, time, record)
-      [tag, time, record].to_msgpack
+      pk = Fluent::MessagePackFactory.packer
+      pk.write([tag, time, record]).to_s
     end
 
     def write(chunk)


### PR DESCRIPTION
Fixes an issue with `msgpack` not being able to serialize `Fluent::EventTime` objects.

Without this fix, any timestamp with subsecond precision will loose information after being bufferized, since `msgpack` will serialize them as integers.

The workaround uses the `MessagePackFactory` class defined in fluentd: https://github.com/fluent/fluentd/blob/master/lib/fluent/msgpack_factory.rb 

Fixes #4 